### PR TITLE
fix(orchestrator): Trigger fallback on zero-op success

### DIFF
--- a/Nirvana_Combined_Orchestrator.js
+++ b/Nirvana_Combined_Orchestrator.js
@@ -658,9 +658,11 @@ function executerPhaseScoresSpecialisee(dataContext, config, scenarios) {
       // Adaptation pour les scénarios spécifiques
       const resultatScores = executerEquilibrageScoresPersonnalise(scenarios, configSpecialisee);
       
-      if (resultatScores && resultatScores.success) {
+      // On ne considère comme un succès que si des opérations ont réellement eu lieu.
+      // Sinon, on veut pouvoir utiliser le fallback.
+      if (resultatScores && resultatScores.success && (resultatScores.totalEchanges || 0) > 0) {
         resultats.success = true;
-        resultats.nbOperations = resultatScores.totalEchanges || 0;
+        resultats.nbOperations = resultatScores.totalEchanges;
         resultats.details = {
           strategieUtilisee: `Spécialisée ${scenarios.join('+')}`,
           scoreInitial: resultatScores.scoreInitial || 0,

--- a/tests/Bugfix.test.js
+++ b/tests/Bugfix.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createSandbox(overrides = {}) {
+  const sandbox = {
+    Logger: { log: () => {} },
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', 'Nirvana_Combined_Orchestrator.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'Nirvana_Combined_Orchestrator.js' });
+
+  Object.assign(sandbox, overrides);
+  return sandbox;
+}
+
+test('déclenche le fallback si la stratégie principale réussit sans faire d\'opérations', () => {
+  const scenarios = ['COM'];
+  let fallbackInvocations = 0;
+
+  const sandbox = createSandbox();
+
+  // La stratégie principale est disponible
+  sandbox.lancerEquilibrageScores_UI = () => {};
+
+  // Elle réussit, mais ne fait aucune opération
+  sandbox.executerEquilibrageScoresPersonnalise = () => ({
+    success: true,
+    totalEchanges: 0
+  });
+
+  // Le fallback est surveillé
+  sandbox.V2_Ameliore_OptimisationEngine = () => {
+    fallbackInvocations += 1;
+    return {
+      success: true,
+      nbSwapsAppliques: 5,
+    };
+  };
+
+  sandbox.executerPhaseScoresSpecialisee({}, {}, scenarios);
+
+  // Le test doit vérifier que le fallback a bien été appelé.
+  assert.strictEqual(fallbackInvocations, 1, 'Le fallback V2 aurait dû être invoqué');
+});


### PR DESCRIPTION
The 'executerPhaseScoresSpecialisee' function was not triggering the fallback mechanism when the primary strategy succeeded but produced no operations. This could lead to suboptimal results as a potentially better fallback strategy was not attempted.

This commit modifies the logic to ensure that the fallback is invoked if the primary strategy either fails or results in zero exchanges. This improves the robustness of the optimization process.

A new test case is added to `tests/Bugfix.test.js` to verify this specific behavior, ensuring the fallback is called as expected.