### PR TITLE
Support alternate ID column names in getEleveById

### DIFF
--- a/tests/getEleveById.test.js
+++ b/tests/getEleveById.test.js
@@ -1,0 +1,60 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadBackendSandbox(overrides = {}) {
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: { log: () => {} },
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({ getSheets: () => [] })
+    },
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', 'BackendV2.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'BackendV2.js' });
+
+  Object.assign(sandbox, overrides);
+  return sandbox;
+}
+
+test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () => {
+  const data = [
+    ['ID_ELEVE', 'Nom', 'Prenom', 'MOB', 'COM'],
+    ['ABC123', 'Durand', 'Alice', 'LIBRE', 42],
+  ];
+
+  const fakeSheet = {
+    getName: () => '6E1TEST',
+    getDataRange: () => ({
+      getValues: () => data,
+    }),
+  };
+
+  const sandbox = loadBackendSandbox({
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({
+        getSheets: () => [fakeSheet],
+      }),
+    },
+  });
+
+  const eleve = sandbox.getEleveById_('ABC123');
+
+  assert.ok(eleve, 'Un élève doit être renvoyé lorsque l\'identifiant correspond.');
+  assert.strictEqual(eleve.id, 'ABC123');
+  assert.strictEqual(eleve.nom, 'Durand');
+  assert.strictEqual(eleve.prenom, 'Alice');
+  assert.strictEqual(eleve.mobilite, 'LIBRE');
+  assert.strictEqual(eleve.scores.C, 42);
+  assert.strictEqual(eleve.scores.T, undefined);
+  assert.strictEqual(eleve.scores.P, undefined);
+  assert.strictEqual(eleve.scores.A, undefined);
+});


### PR DESCRIPTION
## Summary
- resolve student data columns in `getEleveById_` through the shared alias map so headers such as `ID_ELEVE` are accepted
- read optional columns safely with alias-aware lookups while keeping a fallback for historical `DISPO` mobility data
- add a node:test that covers a sheet exposing an `ID_ELEVE` header to ensure the expected student is returned

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68cb9563e3248327a25271c16a337483