### PR TITLE
Introduce NirvanaEngine domain/service and extend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # SEPTEMBRE-25
+
+## Architecture "backend élèves"
+
+Le module `BackendV2.js` expose désormais un noyau `ElevesBackend` organisé par domaines :
+
+* **Domain (`ElevesBackend.createDomain`)** – transforme les lignes des feuilles en objets élèves, résout les alias de colonnes et prépare les règles de structure (capacités, quotas).
+* **Data access (`ElevesBackend.createDataAccess`)** – encapsule l’accès aux feuilles Google Sheets (sélection par suffixe, lecture de `_STRUCTURE`, filtrage des onglets techniques).
+* **Service (`ElevesBackend.createService`)** – orchestre la lecture des données, applique le domaine et renvoie des objets sérialisables pour `getElevesData*` et `getStructureRules`.
+
+Cette séparation permet d’injecter facilement des dépendances pour les tests tout en conservant les fonctions Apps Script historiques (`getElevesData`, `getElevesDataForMode`, `getStructureRules`, `getEleveById_`, etc.).
+
+Une description détaillée figure dans [`docs/architecture.md`](docs/architecture.md).
+
+## Architecture "Nirvana engine"
+
+`Nirvana_Combined_Orchestrator.js` expose désormais un module `NirvanaEngine` structuré de façon similaire :
+
+* **Domain (`NirvanaEngine.createDomain`)** – agrège les résultats des phases V2/Parité, calcule les durées et produit les messages standardisés (alertes, toasts).
+* **Service (`NirvanaEngine.createService`)** – encapsule l’orchestrateur Apps Script : gestion du verrou `LockService`, interaction avec l’UI Google Sheets et injection des dépendances (préparation des données, phases métier).
+
+La fonction `lancerCombinaisonNirvanaOptimale` se contente ainsi d’invoquer le service configuré, ce qui simplifie les tests et la réutilisation du moteur.
+
+## Tests
+
+Les tests unitaires Node utilisent des loaders sandbox (`tests/helpers/loadBackendSandbox.js`, `tests/helpers/loadNirvanaSandbox.js`) pour exécuter `BackendV2.js` et `Nirvana_Combined_Orchestrator.js` hors Apps Script :
+
+```bash
+node --test
+```
+
+Les tests vérifient à la fois le backend élèves (alias d’ID) et l’orchestrateur Nirvana (agrégation des phases, gestion du verrou, interactions UI simulées).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,60 @@
+# Architecture interne – module BackendV2
+
+Cette refonte isole les responsabilités majeures de la chaîne « backend élèves » en trois couches.
+
+## 1. Domaine (`ElevesBackend.createDomain`)
+
+* centralise la résolution des alias déclarés dans `ELEVES_ALIAS` ;
+* expose `createStudent`, `createClassFromSheet` et `buildClassesData` pour transformer les lignes brutes en objets élèves normalisés ;
+* fournit `parseStructureRules` pour interpréter l’onglet `_STRUCTURE` (capacités et quotas) ;
+* garantit la sérialisation stable via `sanitize`.
+
+## 2. Accès données (`ElevesBackend.createDataAccess`)
+
+* encapsule la sélection des feuilles en fonction des suffixes (`TEST`, `CACHE`, `INT`) et filtre les onglets techniques (`level_`, `grp_`, …) ;
+* lit de manière centralisée `_STRUCTURE` et expose `getClassSheetsForSuffix` / `getStructureSheetValues`.
+
+## 3. Service (`ElevesBackend.createService`)
+
+* associe domaine + accès données pour alimenter les fonctions publiques `getElevesData`, `getElevesDataForMode` et `getStructureRules` ;
+* normalise la sélection du suffixe demandé (`resolveSuffix`) et journalise les modes inconnus ;
+* fournit une surface testable facilement injectée dans les tests Node (`tests/elevesService.test.js`).
+
+## Intégration Apps Script
+
+`BackendV2.js` instancie le service avec `SpreadsheetApp` par défaut afin que les fonctions globales historiques restent inchangées pour l’Apps Script UI.
+
+`getEleveById_`, `buildStudentIndex_` et `getAvailableClasses` réutilisent désormais le domaine pour éviter la duplication des règles d’alias.
+
+## Tests
+
+Les nouveaux tests valident :
+
+* la construction du service (`tests/elevesService.test.js`) ;
+* la compatibilité de `getEleveById_` avec les alias (`tests/getEleveById.test.js`).
+
+Cette architecture permet de brancher progressivement d’autres moteurs (API REST, batch Node, etc.) en réutilisant le même cœur métier.
+
+# Architecture interne – Nirvana_Combined_Orchestrator
+
+La refonte de l’orchestrateur combine les mêmes principes de séparation des responsabilités.
+
+## 1. Domaine (`NirvanaEngine.createDomain`)
+
+* valide l’entrée (configuration, `classesState`) avant de lancer les phases ;
+* déclenche les hooks `beforePhase1` / `beforePhase2` pour permettre au service d’afficher toasts et journaux ;
+* agrège les résultats des phases V2/Parité, calcule les durées, le score final et construit un résumé sérialisable (`totalOperations`, `startedAt`, `endedAt`).
+
+## 2. Service (`NirvanaEngine.createService`)
+
+* encapsule les dépendances Apps Script (LockService, `SpreadsheetApp`, `UI`) et gère le verrouillage, les toasts et les alertes ;
+* injecte dynamiquement `getConfig`, `V2_Ameliore_PreparerDonnees`, `combinaisonNirvanaOptimale`, `correctionPariteFinale`, `V2_Ameliore_CalculerEtatGlobal` ;
+* fournit une méthode `runCombination` réutilisée par `lancerCombinaisonNirvanaOptimale` et testable hors environnement Google.
+
+## 3. Tests
+
+* `tests/nirvanaEngine.test.js` vérifie le calcul du résumé (durées, score final, total d’opérations) et le pilotage du verrou/toasts/alertes.
+* `tests/helpers/loadNirvanaSandbox.js` charge le script dans un `vm` Node avec des stubs de `SpreadsheetApp` et `LockService` pour les tests.
+
+Ainsi, la logique métier (phases V2 + Parité) peut être instrumentée, testée et migrée vers d’autres environnements sans dépendre du runtime Apps Script.
+

--- a/tests/elevesService.test.js
+++ b/tests/elevesService.test.js
@@ -1,0 +1,112 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { loadBackendSandbox } = require('./helpers/loadBackendSandbox');
+
+test('ElevesBackend service structure les classes et règles', () => {
+  const sandbox = loadBackendSandbox();
+  const ElevesBackend = sandbox.ElevesBackend;
+
+  const dataAccess = {
+    getClassSheetsForSuffix: (suffix, options = {}) => {
+      assert.strictEqual(suffix, ElevesBackend.config.sheetSuffixes.test);
+      assert.strictEqual(options.includeValues, true);
+      return [
+        {
+          name: `6E1${suffix}`,
+          values: [
+            ['ID_ELEVE', 'Nom', 'Prenom', 'MOB', 'COM'],
+            ['ABC123', 'Durand', 'Alice', 'LIBRE', 42],
+            ['DEF456', 'Martin', 'Bob', '', ''],
+          ],
+        },
+      ];
+    },
+    getStructureSheetValues: () => [
+      ['CLASSE_DEST', 'EFFECTIF', 'OPTIONS'],
+      ['6E1', 28, 'ITA=12'],
+    ],
+  };
+
+  const logger = { log: () => {}, warn: () => {}, error: () => {} };
+  const domain = ElevesBackend.createDomain({ config: ElevesBackend.config, logger });
+  const service = ElevesBackend.createService({
+    config: ElevesBackend.config,
+    domain,
+    dataAccess,
+    logger,
+  });
+
+  const eleves = service.getElevesData();
+
+  const expected = domain.sanitize([
+    {
+      classe: '6E1',
+      eleves: [
+        {
+          id: 'ABC123',
+          nom: 'Durand',
+          prenom: 'Alice',
+          sexe: '',
+          lv2: '',
+          opt: '',
+          disso: '',
+          asso: '',
+          scores: { C: 42, T: 0, P: 0, A: 0 },
+          source: '',
+          dispo: '',
+          mobilite: 'LIBRE',
+        },
+        {
+          id: 'DEF456',
+          nom: 'Martin',
+          prenom: 'Bob',
+          sexe: '',
+          lv2: '',
+          opt: '',
+          disso: '',
+          asso: '',
+          scores: { C: 0, T: 0, P: 0, A: 0 },
+          source: '',
+          dispo: '',
+          mobilite: 'LIBRE',
+        },
+      ],
+    },
+  ]);
+
+  assert.deepStrictEqual(eleves, expected);
+
+  const rules = service.getStructureRules();
+  const expectedRules = domain.sanitize({
+    '6E1': { capacity: 28, quotas: { ITA: 12 } },
+  });
+  assert.deepStrictEqual(rules, expectedRules);
+});
+
+test('ElevesBackend service bascule sur TEST pour un mode inconnu', () => {
+  const sandbox = loadBackendSandbox();
+  const ElevesBackend = sandbox.ElevesBackend;
+
+  const suffixes = [];
+  const dataAccess = {
+    getClassSheetsForSuffix: (suffix) => {
+      suffixes.push(suffix);
+      return [];
+    },
+    getStructureSheetValues: () => null,
+  };
+
+  const logger = { log: () => {}, warn: () => {}, error: () => {} };
+  const domain = ElevesBackend.createDomain({ config: ElevesBackend.config, logger });
+  const service = ElevesBackend.createService({
+    config: ElevesBackend.config,
+    domain,
+    dataAccess,
+    logger,
+  });
+
+  const result = service.getElevesDataForMode('INCONNU');
+  assert.ok(Array.isArray(result));
+  assert.strictEqual(result.length, 0);
+  assert.deepStrictEqual(suffixes, [ElevesBackend.config.sheetSuffixes.test]);
+});

--- a/tests/getEleveById.test.js
+++ b/tests/getEleveById.test.js
@@ -1,29 +1,6 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
-
-function loadBackendSandbox(overrides = {}) {
-  const sandbox = {
-    console: { log: () => {}, warn: () => {}, error: () => {} },
-    Logger: { log: () => {} },
-    SpreadsheetApp: {
-      getActiveSpreadsheet: () => ({ getSheets: () => [] })
-    },
-  };
-
-  sandbox.global = sandbox;
-  sandbox.globalThis = sandbox;
-  sandbox.self = sandbox;
-
-  const filePath = path.join(__dirname, '..', 'BackendV2.js');
-  const code = fs.readFileSync(filePath, 'utf8');
-  vm.runInNewContext(code, sandbox, { filename: 'BackendV2.js' });
-
-  Object.assign(sandbox, overrides);
-  return sandbox;
-}
+const { loadBackendSandbox } = require('./helpers/loadBackendSandbox');
 
 test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () => {
   const data = [
@@ -54,7 +31,7 @@ test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () 
   assert.strictEqual(eleve.prenom, 'Alice');
   assert.strictEqual(eleve.mobilite, 'LIBRE');
   assert.strictEqual(eleve.scores.C, 42);
-  assert.strictEqual(eleve.scores.T, undefined);
-  assert.strictEqual(eleve.scores.P, undefined);
-  assert.strictEqual(eleve.scores.A, undefined);
+  assert.strictEqual(eleve.scores.T, 0);
+  assert.strictEqual(eleve.scores.P, 0);
+  assert.strictEqual(eleve.scores.A, 0);
 });

--- a/tests/helpers/loadBackendSandbox.js
+++ b/tests/helpers/loadBackendSandbox.js
@@ -1,0 +1,26 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadBackendSandbox(overrides = {}) {
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: { log: () => {} },
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({ getSheets: () => [] })
+    },
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', '..', 'BackendV2.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'BackendV2.js' });
+
+  Object.assign(sandbox, overrides);
+  return sandbox;
+}
+
+module.exports = { loadBackendSandbox };

--- a/tests/helpers/loadNirvanaSandbox.js
+++ b/tests/helpers/loadNirvanaSandbox.js
@@ -1,0 +1,71 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createDefaultSpreadsheet() {
+  const alerts = [];
+  const toasts = [];
+  return {
+    _alerts: alerts,
+    _toasts: toasts,
+    toast(message, title, seconds) {
+      toasts.push({ message, title, seconds });
+    },
+    getUi() {
+      return {
+        ButtonSet: { OK: 'OK' },
+        _alerts: alerts,
+        alert(title, message, button) {
+          alerts.push({ title, message, button });
+        }
+      };
+    }
+  };
+}
+
+function loadNirvanaSandbox(overrides = {}) {
+  const spreadsheet = createDefaultSpreadsheet();
+
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {}
+    },
+    LockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {}
+      })
+    },
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => spreadsheet
+    },
+    Date,
+    JSON,
+    Math,
+    Number,
+    String,
+    Array,
+    Object,
+    RegExp,
+    Error,
+    isFinite
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', '..', 'Nirvana_Combined_Orchestrator.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'Nirvana_Combined_Orchestrator.js' });
+
+  Object.assign(sandbox, overrides);
+  sandbox.__spreadsheet = spreadsheet;
+
+  return sandbox;
+}
+
+module.exports = { loadNirvanaSandbox };

--- a/tests/nirvanaEngine.test.js
+++ b/tests/nirvanaEngine.test.js
@@ -1,0 +1,115 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { loadNirvanaSandbox } = require('./helpers/loadNirvanaSandbox');
+
+function createTimeProvider(instants) {
+  let index = 0;
+  return () => {
+    const value = instants[index];
+    if (index < instants.length - 1) {
+      index += 1;
+    }
+    return value instanceof Date ? value : new Date(value);
+  };
+}
+
+test('NirvanaEngine domain agrège les résultats et formate le message', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.NirvanaEngine.createDomain({ logger: sandbox.Logger });
+
+  const start = new Date('2025-01-01T10:00:00Z');
+  const end = new Date('2025-01-01T10:00:10Z');
+
+  const summary = domain.runCombined({
+    config: { demo: true },
+    dataContext: { classesState: {} },
+    runV2Phase: () => ({ swapsV2: [1, 2, 3], cyclesGeneraux: 2, cyclesParite: 1 }),
+    runParityPhase: () => ({ nbApplied: 4 }),
+    computeState: () => ({ scoreGlobal: 87.1234 }),
+    now: createTimeProvider([end]),
+    startedAt: start
+  });
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.swapsV2, 3);
+  assert.equal(summary.cyclesGeneraux, 2);
+  assert.equal(summary.cyclesParite, 1);
+  assert.equal(summary.operationsParity, 4);
+  assert.equal(summary.totalOperations, 7);
+  assert.equal(summary.tempsMs, 10000);
+  assert.equal(summary.scoreFinal, 87.1234);
+  assert.equal(summary.startedAt.toISOString(), start.toISOString());
+  assert.equal(summary.endedAt.toISOString(), end.toISOString());
+
+  const message = domain.formatSuccess(summary);
+  assert.match(message, /Swaps principaux: 3/);
+  assert.match(message, /Corrections parité: 4/);
+  assert.match(message, /Score final: 87\.12\/100/);
+  assert.match(message, /Durée totale: 10\.0 secondes/);
+});
+
+test('NirvanaEngine service orchestre les verrous et interactions UI', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.NirvanaEngine.createDomain({ logger: sandbox.Logger });
+
+  let released = false;
+  const toasts = [];
+  const alerts = [];
+
+  const spreadsheet = {
+    toast(message, title, seconds) {
+      toasts.push({ message, title, seconds });
+    },
+    getUi() {
+      return {
+        ButtonSet: { OK: 'OK' },
+        alert(title, message, button) {
+          alerts.push({ title, message, button });
+        }
+      };
+    }
+  };
+
+  const service = sandbox.NirvanaEngine.createService({
+    domain,
+    getConfig: () => ({ demo: true }),
+    prepareData: () => ({ classesState: {} }),
+    runV2Phase: () => ({ swapsV2: ['a'], cyclesGeneraux: 1, cyclesParite: 2 }),
+    runParityPhase: () => ({ nbApplied: 3 }),
+    computeState: () => ({ scoreGlobal: 91 }),
+    spreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    lockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {
+          released = true;
+        }
+      })
+    },
+    logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {}
+    },
+    now: createTimeProvider([
+      new Date('2025-01-01T08:00:00Z'),
+      new Date('2025-01-01T08:00:05Z'),
+      new Date('2025-01-01T08:00:07Z')
+    ])
+  });
+
+  const result = service.runCombination();
+
+  assert.equal(result.success, true);
+  assert.equal(result.swapsV2, 1);
+  assert.equal(result.operationsParity, 3);
+  assert.equal(result.totalOperations, 4);
+  assert.equal(result.scoreFinal, 91);
+  assert.equal(result.tempsMs, 5000);
+  assert.equal(released, true);
+  assert.equal(toasts.length, 4);
+  assert.equal(alerts.length, 1);
+  assert.match(alerts[0].message, /Swaps principaux: 1/);
+  assert.match(toasts[toasts.length - 1].message, /4 opérations appliquées/);
+});


### PR DESCRIPTION
## Summary
- extract a reusable `NirvanaEngine` domain/service inside `Nirvana_Combined_Orchestrator.js` to handle locking, UI hooks and phase aggregation
- simplify `lancerCombinaisonNirvanaOptimale` to call the shared service and keep the legacy phase functions intact
- add a dedicated sandbox loader and Node tests that validate the new engine behaviour plus update documentation to describe the orchestration layer

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68cb949010a48327993c52290d624535