### PR TITLE
Introduce Nirvana data backend service

### DIFF
--- a/Nirvana_DataBackend.js
+++ b/Nirvana_DataBackend.js
@@ -1,0 +1,243 @@
+'use strict';
+
+const NirvanaDataBackend = (function (global) {
+  const noop = () => {};
+  const defaultLogger = (global.Logger && {
+    log: (...args) => global.Logger.log(...args),
+    warn: (...args) => (global.Logger.warn ? global.Logger.warn(...args) : noop()),
+    error: (...args) => (global.Logger.error ? global.Logger.error(...args) : global.Logger.log(...args))
+  }) || global.console || { log: noop, warn: noop, error: noop };
+
+  const DEFAULT_CRITERIA = ['COM', 'TRA', 'PART'];
+
+  function ensureArray(value) {
+    return Array.isArray(value) ? value.slice() : [];
+  }
+
+  function toClassKey(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value).trim();
+  }
+
+  function createEmptyDistribution(criteria = DEFAULT_CRITERIA) {
+    return criteria.reduce((acc, critere) => {
+      acc[critere] = { '1': 0, '2': 0, '3': 0, '4': 0 };
+      return acc;
+    }, {});
+  }
+
+  function createEmptyCaches(classesState, criteria = DEFAULT_CRITERIA) {
+    const caches = {};
+    Object.keys(classesState).forEach(classe => {
+      const dist = criteria.reduce((acc, critere) => {
+        acc[critere] = { 1: 0, 2: 0, 3: 0, 4: 0 };
+        return acc;
+      }, {});
+      caches[classe] = {
+        dist,
+        parite: { F: 0, M: 0, total: 0 },
+        score: 0
+      };
+    });
+    return caches;
+  }
+
+  function createDomain({
+    computeDistribution = global.V2_Ameliore_CalculerDistributionGlobale,
+    buildDissocCountMap = global.buildDissocCountMap,
+    logger = defaultLogger
+  } = {}) {
+    function buildClassesState(students) {
+      const classesState = {};
+      const effectifsClasses = {};
+
+      ensureArray(students).forEach(student => {
+        if (!student) return;
+        const classe = toClassKey(student.CLASSE);
+        if (!classe) return;
+        if (!classesState[classe]) {
+          classesState[classe] = [];
+        }
+        classesState[classe].push(student);
+      });
+
+      Object.keys(classesState).forEach(classe => {
+        effectifsClasses[classe] = classesState[classe].length;
+      });
+
+      return { classesState, effectifsClasses };
+    }
+
+    function buildTargets({ classesState, distributionGlobale, totalEleves, criteria = DEFAULT_CRITERIA }) {
+      const ciblesParClasse = {};
+      const total = Number.isFinite(totalEleves) ? totalEleves : 0;
+      const distribution = distributionGlobale || createEmptyDistribution(criteria);
+
+      Object.keys(classesState).forEach(classe => {
+        const effectifClasse = classesState[classe].length;
+        ciblesParClasse[classe] = {};
+        criteria.forEach(critere => {
+          ciblesParClasse[classe][critere] = {};
+          const globalCritere = distribution[critere] || {};
+          ['1', '2', '3', '4'].forEach(score => {
+            const totalScore = Number(globalCritere[score]) || 0;
+            const cible = total > 0 ? Math.round((effectifClasse / total) * totalScore) : 0;
+            ciblesParClasse[classe][critere][score] = cible;
+          });
+        });
+      });
+
+      return ciblesParClasse;
+    }
+
+    function prepareContext({
+      config,
+      students,
+      optionPools = {},
+      structure,
+      colIndexes = {},
+      criteria = DEFAULT_CRITERIA
+    } = {}) {
+      const elevesValides = ensureArray(students);
+      const { classesState, effectifsClasses } = buildClassesState(elevesValides);
+      const totalEleves = elevesValides.length;
+      const nbClasses = Object.keys(classesState).length;
+
+      const distribution =
+        typeof computeDistribution === 'function'
+          ? computeDistribution(elevesValides, criteria)
+          : createEmptyDistribution(criteria);
+
+      const ciblesParClasse = buildTargets({
+        classesState,
+        distributionGlobale: distribution,
+        totalEleves,
+        criteria
+      });
+
+      const dissocMap =
+        typeof buildDissocCountMap === 'function'
+          ? buildDissocCountMap(classesState)
+          : {};
+
+      const dataContext = {
+        config,
+        elevesValides,
+        classesState,
+        effectifsClasses,
+        optionPools: optionPools || {},
+        structureData: structure,
+        colIndexes: colIndexes || {},
+        dissocMap,
+        distributionGlobale: distribution,
+        ciblesParClasse,
+        totalEleves,
+        nbClasses
+      };
+
+      dataContext.classeCaches = createEmptyCaches(classesState, criteria);
+      dataContext.scoreGlobal = 0;
+
+      return dataContext;
+    }
+
+    return {
+      prepareContext,
+      buildClassesState,
+      buildTargets
+    };
+  }
+
+  function createService({
+    domain = createDomain(),
+    getConfig = global.getConfig,
+    determineActiveLevel = global.determinerNiveauActifCache,
+    loadStructure = global.chargerStructureEtOptions,
+    buildOptionPools = global.buildOptionPools,
+    loadStudents = global.chargerElevesEtClasses_AvecSEXE || global.chargerElevesEtClasses,
+    sanitizeStudents = global.sanitizeStudents,
+    classifyStudents = global.classifierEleves,
+    criteria = ['COM', 'TRA', 'PART', 'ABS'],
+    logger = defaultLogger
+  } = {}) {
+    function prepareData({ config: configArg, criteresUI } = {}) {
+      let config = configArg;
+      if (!config && typeof getConfig === 'function') {
+        config = getConfig(criteresUI);
+      }
+      if (!config || typeof config !== 'object') {
+        throw new Error('Configuration Nirvana invalide');
+      }
+
+      const activeLevel =
+        typeof determineActiveLevel === 'function' ? determineActiveLevel(config) : null;
+
+      const structureResult =
+        typeof loadStructure === 'function' ? loadStructure(activeLevel, config) : null;
+      if (!structureResult || structureResult.success === false || !structureResult.structure) {
+        throw new Error('Échec chargement structure Nirvana');
+      }
+
+      const optionPools =
+        typeof buildOptionPools === 'function'
+          ? buildOptionPools(structureResult.structure, config)
+          : {};
+
+      const loader = typeof loadStudents === 'function' ? loadStudents : () => ({ success: false });
+      const loadResult = loader(config, config && config.MOBILITE_FIELD ? config.MOBILITE_FIELD : 'MOBILITE');
+      if (!loadResult || loadResult.success === false) {
+        throw new Error('Échec chargement élèves Nirvana');
+      }
+
+      const sanitized =
+        typeof sanitizeStudents === 'function'
+          ? sanitizeStudents(loadResult.students)
+          : { clean: Array.isArray(loadResult.students) ? loadResult.students : [] };
+
+      const elevesValides = ensureArray(sanitized.clean);
+
+      if (typeof classifyStudents === 'function') {
+        try {
+          classifyStudents(elevesValides, criteria);
+        } catch (err) {
+          if (logger && typeof logger.warn === 'function') {
+            logger.warn('NirvanaDataBackend: échec de la classification des élèves', err);
+          }
+        }
+      }
+
+      const distributionCriteria = criteria.filter(critere => critere !== 'ABS');
+
+      return domain.prepareContext({
+        config,
+        students: elevesValides,
+        optionPools,
+        structure: structureResult.structure,
+        colIndexes: loadResult.colIndexes,
+        criteria: distributionCriteria
+      });
+    }
+
+    return { prepareData };
+  }
+
+  const api = {
+    createDomain,
+    createService
+  };
+
+  global.NirvanaDataBackend = api;
+  return api;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+
+const __nirvanaDataLogger =
+  (typeof Logger !== 'undefined' && Logger) ||
+  (typeof console !== 'undefined' ? console : { log: () => {}, warn: () => {}, error: () => {} });
+const __nirvanaDataDomain = NirvanaDataBackend.createDomain({ logger: __nirvanaDataLogger });
+const __nirvanaDataService = NirvanaDataBackend.createService({
+  domain: __nirvanaDataDomain,
+  logger: __nirvanaDataLogger
+});
+

--- a/Nirvana_V2_Amelioree.js
+++ b/Nirvana_V2_Amelioree.js
@@ -271,87 +271,12 @@ try {
 // SECTION 2: PRÉPARATION DES DONNÉES
 // ==================================================================
 
-function V2_Ameliore_PreparerDonnees(config) {
-  // Réutilisation des fonctions existantes V14
-  const niveauActif = determinerNiveauActifCache();
-  const structureResult = chargerStructureEtOptions(niveauActif, config);
-  if (!structureResult.success) throw new Error("Échec chargement structure");
-  
-  const optionPools = buildOptionPools(structureResult.structure, config);
-  Logger.log("V2 Amélioré: Option pools chargés: " + JSON.stringify(optionPools));
-  
-  const chargeResult = chargerElevesEtClasses(config, "MOBILITE");
-  if (!chargeResult.success) throw new Error("Échec chargement élèves");
-  
-  const { clean: elevesValides } = sanitizeStudents(chargeResult.students);
-  classifierEleves(elevesValides, ['COM', 'TRA', 'PART', 'ABS']);
-  
-  // Organisation par classe
-  const classesState = {};
-  const effectifsClasses = {};
-  
-  elevesValides.forEach(eleve => {
-    const classe = eleve.CLASSE;
-    if (!classe) return;
-    
-    if (!classesState[classe]) classesState[classe] = [];
-    classesState[classe].push(eleve);
-  });
-  
-  Object.keys(classesState).forEach(cls => {
-    effectifsClasses[cls] = classesState[cls].length;
-  });
-  
-  // Calcul des distributions globales actuelles pour chaque critère
-  const distributionGlobale = V2_Ameliore_CalculerDistributionGlobale(elevesValides, ['COM', 'TRA', 'PART']);
-  
-  // Calcul des cibles idéales basées sur la distribution globale actuelle
-  const totalEleves = elevesValides.length;
-  const nbClasses = Object.keys(classesState).length;
-  
-  const ciblesParClasse = {};
-  Object.keys(classesState).forEach(classe => {
-    const effectifClasse = classesState[classe].length;
-    ciblesParClasse[classe] = {};
-    
-    ['COM', 'TRA', 'PART'].forEach(critere => {
-      ciblesParClasse[classe][critere] = {};
-      ['1', '2', '3', '4'].forEach(score => {
-        // Cible proportionnelle à la distribution globale
-        const totalScore = distributionGlobale[critere][score];
-        const cible = Math.round((effectifClasse / totalEleves) * totalScore);
-        ciblesParClasse[classe][critere][score] = cible;
-      });
-    });
-  });
-  
-  const dataContext = {
-    config: config,
-    elevesValides: elevesValides,
-    classesState: classesState,
-    effectifsClasses: effectifsClasses,
-    optionPools: optionPools,
-    structureData: structureResult.structure,
-    colIndexes: chargeResult.colIndexes,
-    dissocMap: buildDissocCountMap(classesState),
-    distributionGlobale: distributionGlobale,
-    ciblesParClasse: ciblesParClasse,
-    totalEleves: totalEleves,
-    nbClasses: nbClasses
-  };
-  
-  dataContext.totalEleves = elevesValides.length;
-  dataContext.classeCaches = {};
-  Object.keys(dataContext.classesState).forEach(cls => {
-    dataContext.classeCaches[cls] = {
-      dist: { COM: {1:0,2:0,3:0,4:0}, TRA: {1:0,2:0,3:0,4:0}, PART: {1:0,2:0,3:0,4:0} },
-      parite: { F: 0, M: 0, total: 0 },
-      score: 0
-    };
-  });
-  dataContext.scoreGlobal = 0;
-  
-  return dataContext;
+function V2_Ameliore_PreparerDonnees(config, criteresUI) {
+  if (!__nirvanaDataService || typeof __nirvanaDataService.prepareData !== 'function') {
+    throw new Error('NirvanaDataBackend indisponible pour préparer les données');
+  }
+
+  return __nirvanaDataService.prepareData({ config, criteresUI });
 }
 
 // ==================================================================
@@ -1873,91 +1798,12 @@ function normaliserSexeSimple(raw) {
 /**
  * Patch de V2_Ameliore_PreparerDonnees pour utiliser la version avec SEXE
  */
-function V2_Ameliore_PreparerDonnees_AvecSEXE(config) {
-  Logger.log("V2_Ameliore_PreparerDonnees_AvecSEXE: Utilisation du chargeur avec SEXE");
-  
-  const niveauActif = determinerNiveauActifCache();
-  const structureResult = chargerStructureEtOptions(niveauActif, config);
-  if (!structureResult.success) throw new Error("Échec chargement structure");
-  
-  const optionPools = buildOptionPools(structureResult.structure, config);
-  Logger.log("Option pools: " + JSON.stringify(optionPools));
-  
-  // *** UTILISER LA VERSION PATCHÉE ***
-  const chargeResult = chargerElevesEtClasses_AvecSEXE(config, "MOBILITE");
-  if (!chargeResult.success) throw new Error("Échec chargement élèves");
-  
-  const { clean: elevesValides } = sanitizeStudents(chargeResult.students);
-  classifierEleves(elevesValides, ['COM', 'TRA', 'PART', 'ABS']);
-  
-  // Organisation par classe
-  const classesState = {};
-  const effectifsClasses = {};
-  
-  elevesValides.forEach(eleve => {
-    const classe = eleve.CLASSE;
-    if (!classe) return;
-    
-    if (!classesState[classe]) classesState[classe] = [];
-    classesState[classe].push(eleve);
-  });
-  
-  Object.keys(classesState).forEach(cls => {
-    effectifsClasses[cls] = classesState[cls].length;
-    
-    // Log rapide de la parité
-    const nbF = classesState[cls].filter(e => e.SEXE === 'F').length;
-    const nbM = classesState[cls].filter(e => e.SEXE === 'M').length;
-    Logger.log(`${cls}: ${nbF}F/${nbM}M`);
-  });
-  
-  // Reste du code identique...
-  const distributionGlobale = V2_Ameliore_CalculerDistributionGlobale(elevesValides, ['COM', 'TRA', 'PART']);
-  const totalEleves = elevesValides.length;
-  const nbClasses = Object.keys(classesState).length;
-  
-  const ciblesParClasse = {};
-  Object.keys(classesState).forEach(classe => {
-    const effectifClasse = classesState[classe].length;
-    ciblesParClasse[classe] = {};
-    
-    ['COM', 'TRA', 'PART'].forEach(critere => {
-      ciblesParClasse[classe][critere] = {};
-      ['1', '2', '3', '4'].forEach(score => {
-        const totalScore = distributionGlobale[critere][score];
-        const cible = Math.round((effectifClasse / totalEleves) * totalScore);
-        ciblesParClasse[classe][critere][score] = cible;
-      });
-    });
-  });
-  
-  const dataContext = {
-    config: config,
-    elevesValides: elevesValides,
-    classesState: classesState,
-    effectifsClasses: effectifsClasses,
-    optionPools: optionPools,
-    structureData: structureResult.structure,
-    colIndexes: chargeResult.colIndexes,
-    dissocMap: buildDissocCountMap(classesState),
-    distributionGlobale: distributionGlobale,
-    ciblesParClasse: ciblesParClasse,
-    totalEleves: totalEleves,
-    nbClasses: nbClasses
-  };
-  
-  dataContext.totalEleves = elevesValides.length;
-  dataContext.classeCaches = {};
-  Object.keys(dataContext.classesState).forEach(cls => {
-    dataContext.classeCaches[cls] = {
-      dist: { COM: {1:0,2:0,3:0,4:0}, TRA: {1:0,2:0,3:0,4:0}, PART: {1:0,2:0,3:0,4:0} },
-      parite: { F: 0, M: 0, total: 0 },
-      score: 0
-    };
-  });
-  dataContext.scoreGlobal = 0;
-  
-  return dataContext;
+function V2_Ameliore_PreparerDonnees_AvecSEXE(config, criteresUI) {
+  if (!__nirvanaDataService || typeof __nirvanaDataService.prepareData !== 'function') {
+    throw new Error('NirvanaDataBackend indisponible pour préparer les données (SEXE)');
+  }
+
+  return __nirvanaDataService.prepareData({ config, criteresUI });
 }
 
 /**
@@ -2264,8 +2110,8 @@ function chargerElevesEtClasses(config, mobiliteField) {
 }
 
 // ② Préparation des données V2 : on remplace la version legacy
-function V2_Ameliore_PreparerDonnees(config) {
-  return V2_Ameliore_PreparerDonnees_AvecSEXE(config);
+function V2_Ameliore_PreparerDonnees(config, criteresUI) {
+  return V2_Ameliore_PreparerDonnees_AvecSEXE(config, criteresUI);
 }
 
 // ③ Parité agressive : alias pour rester compatible avec les menus

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # SEPTEMBRE-25
+
+## Architecture "backend élèves"
+
+Le module `BackendV2.js` expose désormais un noyau `ElevesBackend` organisé par domaines :
+
+* **Domain (`ElevesBackend.createDomain`)** – transforme les lignes des feuilles en objets élèves, résout les alias de colonnes et prépare les règles de structure (capacités, quotas).
+* **Data access (`ElevesBackend.createDataAccess`)** – encapsule l’accès aux feuilles Google Sheets (sélection par suffixe, lecture de `_STRUCTURE`, filtrage des onglets techniques).
+* **Service (`ElevesBackend.createService`)** – orchestre la lecture des données, applique le domaine et renvoie des objets sérialisables pour `getElevesData*` et `getStructureRules`.
+
+Cette séparation permet d’injecter facilement des dépendances pour les tests tout en conservant les fonctions Apps Script historiques (`getElevesData`, `getElevesDataForMode`, `getStructureRules`, `getEleveById_`, etc.).
+
+Une description détaillée figure dans [`docs/architecture.md`](docs/architecture.md).
+
+## Architecture "Nirvana engine"
+
+`Nirvana_Combined_Orchestrator.js` expose désormais un module `NirvanaEngine` structuré de façon similaire :
+
+* **Domain (`NirvanaEngine.createDomain`)** – agrège les résultats des phases V2/Parité, calcule les durées et produit les messages standardisés (alertes, toasts).
+* **Service (`NirvanaEngine.createService`)** – encapsule l’orchestrateur Apps Script : gestion du verrou `LockService`, interaction avec l’UI Google Sheets et injection des dépendances (préparation des données, phases métier).
+
+La fonction `lancerCombinaisonNirvanaOptimale` se contente ainsi d’invoquer le service configuré, ce qui simplifie les tests et la réutilisation du moteur.
+
+## Architecture "Nirvana data backend"
+
+`Nirvana_DataBackend.js` factorise la préparation du contexte utilisé par Nirvana V2 et les variantes parité :
+
+* **Domain (`NirvanaDataBackend.createDomain`)** – regroupe les élèves par classe, calcule les effectifs/cibles et génère les caches internes (`classeCaches`, `dissocMap`).
+* **Service (`NirvanaDataBackend.createService`)** – orchestre la lecture des feuilles (`chargerElevesEtClasses_AvecSEXE`), la sanitation et la classification avant de remettre un `dataContext` unique aux moteurs historiques.
+
+Les fonctions `V2_Ameliore_PreparerDonnees*` deviennent de simples wrappers vers ce service, ce qui garantit un comportement homogène entre Apps Script et les tests Node.
+
+## Tests
+
+Les tests unitaires Node utilisent des loaders sandbox (`tests/helpers/loadBackendSandbox.js`, `tests/helpers/loadNirvanaSandbox.js`) pour exécuter `BackendV2.js` et `Nirvana_Combined_Orchestrator.js` hors Apps Script :
+
+```bash
+node --test
+```
+
+La suite couvre désormais :
+
+* le backend élèves (alias d’ID, sélection des suffixes) ;
+* le data backend Nirvana (construction du `dataContext`, gestion des erreurs de classification) ;
+* l’orchestrateur combiné (agrégation des phases, verrouillage, toasts/alertes).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ La fonction `lancerCombinaisonNirvanaOptimale` se contente ainsi d’invoquer le
 
 Les fonctions `V2_Ameliore_PreparerDonnees*` deviennent de simples wrappers vers ce service, ce qui garantit un comportement homogène entre Apps Script et les tests Node.
 
+## Architecture "Scores phase engine"
+
+`Nirvana_Combined_Orchestrator.js` embarque désormais `ScoresEquilibrageEngine`, un noyau léger dédié à la phase spécialisée « scores » :
+
+* **Domain (`ScoresEquilibrageEngine.createDomain`)** – séquence l’exécution de la stratégie spécialisée et du fallback Nirvana V2, capitalise les tentatives dans un historique et homogénéise les métriques (`nbOperations`, stratégie retenue) pour l’orchestrateur.
+* **Service (`ScoresEquilibrageEngine.createService`)** – prépare la configuration agressive (`COLONNES_SCORES_ACTIVES`, `MAX_ITERATIONS_SCORES`), injecte les dépendances Apps Script (`executerEquilibrageScoresPersonnalise`, `V2_Ameliore_OptimisationEngine`) et renvoie un rapport testable hors Google Sheets.
+
+La fonction `executerPhaseScoresSpecialisee` délègue ainsi l’intégralité de la logique à ce moteur, ce qui simplifie l’instrumentation et le pilotage des différents scénarios d’équilibrage.
+
 ## Tests
 
 Les tests unitaires Node utilisent des loaders sandbox (`tests/helpers/loadBackendSandbox.js`, `tests/helpers/loadNirvanaSandbox.js`) pour exécuter `BackendV2.js` et `Nirvana_Combined_Orchestrator.js` hors Apps Script :
@@ -42,4 +51,5 @@ La suite couvre désormais :
 
 * le backend élèves (alias d’ID, sélection des suffixes) ;
 * le data backend Nirvana (construction du `dataContext`, gestion des erreurs de classification) ;
-* l’orchestrateur combiné (agrégation des phases, verrouillage, toasts/alertes).
+* l’orchestrateur combiné (agrégation des phases, verrouillage, toasts/alertes) ;
+* le moteur de phase scores (enchaînement stratégie spécialisée/fallback, préparation de configuration).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,80 @@
+# Architecture interne – module BackendV2
+
+Cette refonte isole les responsabilités majeures de la chaîne « backend élèves » en trois couches.
+
+## 1. Domaine (`ElevesBackend.createDomain`)
+
+* centralise la résolution des alias déclarés dans `ELEVES_ALIAS` ;
+* expose `createStudent`, `createClassFromSheet` et `buildClassesData` pour transformer les lignes brutes en objets élèves normalisés ;
+* fournit `parseStructureRules` pour interpréter l’onglet `_STRUCTURE` (capacités et quotas) ;
+* garantit la sérialisation stable via `sanitize`.
+
+## 2. Accès données (`ElevesBackend.createDataAccess`)
+
+* encapsule la sélection des feuilles en fonction des suffixes (`TEST`, `CACHE`, `INT`) et filtre les onglets techniques (`level_`, `grp_`, …) ;
+* lit de manière centralisée `_STRUCTURE` et expose `getClassSheetsForSuffix` / `getStructureSheetValues`.
+
+## 3. Service (`ElevesBackend.createService`)
+
+* associe domaine + accès données pour alimenter les fonctions publiques `getElevesData`, `getElevesDataForMode` et `getStructureRules` ;
+* normalise la sélection du suffixe demandé (`resolveSuffix`) et journalise les modes inconnus ;
+* fournit une surface testable facilement injectée dans les tests Node (`tests/elevesService.test.js`).
+
+## Intégration Apps Script
+
+`BackendV2.js` instancie le service avec `SpreadsheetApp` par défaut afin que les fonctions globales historiques restent inchangées pour l’Apps Script UI.
+
+`getEleveById_`, `buildStudentIndex_` et `getAvailableClasses` réutilisent désormais le domaine pour éviter la duplication des règles d’alias.
+
+## Tests
+
+Les nouveaux tests valident :
+
+* la construction du service (`tests/elevesService.test.js`) ;
+* la compatibilité de `getEleveById_` avec les alias (`tests/getEleveById.test.js`).
+
+Cette architecture permet de brancher progressivement d’autres moteurs (API REST, batch Node, etc.) en réutilisant le même cœur métier.
+
+# Architecture interne – Nirvana_DataBackend
+
+Le module `Nirvana_DataBackend.js` généralise la préparation du contexte de données utilisé par les moteurs Nirvana.
+
+## 1. Domaine (`NirvanaDataBackend.createDomain`)
+
+* agrège les élèves par classes, calcule les effectifs et construit les cibles par classe à partir de la distribution globale ;
+* délègue le calcul de distribution à `V2_Ameliore_CalculerDistributionGlobale` (surchargé au besoin dans les tests) ;
+* expose `prepareContext` pour fabriquer un `dataContext` complet (caches, dissociations, cibles) à partir d’entrées normalisées.
+
+## 2. Service (`NirvanaDataBackend.createService`)
+
+* centralise l’accès aux dépendances Apps Script (`determinerNiveauActifCache`, `chargerStructureEtOptions`, `chargerElevesEtClasses_AvecSEXE`, `sanitizeStudents`, `classifierEleves`) ;
+* produit un contexte unique en journalisant les erreurs de classification et en acceptant des critères configurables ;
+* alimente directement `V2_Ameliore_PreparerDonnees` et `V2_Ameliore_PreparerDonnees_AvecSEXE` qui deviennent de simples wrappers.
+
+## 3. Tests
+
+* `tests/nirvanaDataBackend.test.js` valide la construction du contexte et la tolérance aux erreurs de classification sans dépendre de Google Sheets.
+
+# Architecture interne – Nirvana_Combined_Orchestrator
+
+La refonte de l’orchestrateur combine les mêmes principes de séparation des responsabilités.
+
+## 1. Domaine (`NirvanaEngine.createDomain`)
+
+* valide l’entrée (configuration, `classesState`) avant de lancer les phases ;
+* déclenche les hooks `beforePhase1` / `beforePhase2` pour permettre au service d’afficher toasts et journaux ;
+* agrège les résultats des phases V2/Parité, calcule les durées, le score final et construit un résumé sérialisable (`totalOperations`, `startedAt`, `endedAt`).
+
+## 2. Service (`NirvanaEngine.createService`)
+
+* encapsule les dépendances Apps Script (LockService, `SpreadsheetApp`, `UI`) et gère le verrouillage, les toasts et les alertes ;
+* injecte dynamiquement `getConfig`, `V2_Ameliore_PreparerDonnees`, `combinaisonNirvanaOptimale`, `correctionPariteFinale`, `V2_Ameliore_CalculerEtatGlobal` ;
+* fournit une méthode `runCombination` réutilisée par `lancerCombinaisonNirvanaOptimale` et testable hors environnement Google.
+
+## 3. Tests
+
+* `tests/nirvanaEngine.test.js` vérifie le calcul du résumé (durées, score final, total d’opérations) et le pilotage du verrou/toasts/alertes.
+* `tests/helpers/loadNirvanaSandbox.js` charge le script dans un `vm` Node avec des stubs de `SpreadsheetApp` et `LockService` pour les tests.
+
+Ainsi, la logique métier (phases V2 + Parité) peut être instrumentée, testée et migrée vers d’autres environnements sans dépendre du runtime Apps Script.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,3 +78,23 @@ La refonte de l’orchestrateur combine les mêmes principes de séparation des 
 
 Ainsi, la logique métier (phases V2 + Parité) peut être instrumentée, testée et migrée vers d’autres environnements sans dépendre du runtime Apps Script.
 
+# Architecture interne – ScoresEquilibrageEngine
+
+La phase spécialisée « scores » dispose désormais d’un noyau dédié embarqué dans `Nirvana_Combined_Orchestrator.js`.
+
+## 1. Domaine (`ScoresEquilibrageEngine.createDomain`)
+
+* orchestre la séquence « stratégie spécialisée → fallback Nirvana V2 » ;
+* normalise les sorties (`nbOperations`, stratégie retenue, cycles) et historise chaque tentative (`history`) pour faciliter l’analyse ;
+* gère les erreurs en isolant les exceptions et en garantissant une réponse sérialisable pour l’orchestrateur.
+
+## 2. Service (`ScoresEquilibrageEngine.createService`)
+
+* prépare la configuration spécifique aux scores (colonnes actives, mode agressif, itérations maximales) sans muter l’entrée ;
+* injecte les dépendances Apps Script (`executerEquilibrageScoresPersonnalise`, `V2_Ameliore_OptimisationEngine`) et les expose sous forme de callbacks testables ;
+* enrichit le rapport final (config utilisée, scénarios) pour simplifier le débogage.
+
+## 3. Tests
+
+* `tests/scoresPhaseEngine.test.js` vérifie l’ordre des tentatives, la préparation de configuration et la remontée des métriques clés hors Apps Script.
+

--- a/tests/elevesService.test.js
+++ b/tests/elevesService.test.js
@@ -1,0 +1,112 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { loadBackendSandbox } = require('./helpers/loadBackendSandbox');
+
+test('ElevesBackend service structure les classes et règles', () => {
+  const sandbox = loadBackendSandbox();
+  const ElevesBackend = sandbox.ElevesBackend;
+
+  const dataAccess = {
+    getClassSheetsForSuffix: (suffix, options = {}) => {
+      assert.strictEqual(suffix, ElevesBackend.config.sheetSuffixes.test);
+      assert.strictEqual(options.includeValues, true);
+      return [
+        {
+          name: `6E1${suffix}`,
+          values: [
+            ['ID_ELEVE', 'Nom', 'Prenom', 'MOB', 'COM'],
+            ['ABC123', 'Durand', 'Alice', 'LIBRE', 42],
+            ['DEF456', 'Martin', 'Bob', '', ''],
+          ],
+        },
+      ];
+    },
+    getStructureSheetValues: () => [
+      ['CLASSE_DEST', 'EFFECTIF', 'OPTIONS'],
+      ['6E1', 28, 'ITA=12'],
+    ],
+  };
+
+  const logger = { log: () => {}, warn: () => {}, error: () => {} };
+  const domain = ElevesBackend.createDomain({ config: ElevesBackend.config, logger });
+  const service = ElevesBackend.createService({
+    config: ElevesBackend.config,
+    domain,
+    dataAccess,
+    logger,
+  });
+
+  const eleves = service.getElevesData();
+
+  const expected = domain.sanitize([
+    {
+      classe: '6E1',
+      eleves: [
+        {
+          id: 'ABC123',
+          nom: 'Durand',
+          prenom: 'Alice',
+          sexe: '',
+          lv2: '',
+          opt: '',
+          disso: '',
+          asso: '',
+          scores: { C: 42, T: 0, P: 0, A: 0 },
+          source: '',
+          dispo: '',
+          mobilite: 'LIBRE',
+        },
+        {
+          id: 'DEF456',
+          nom: 'Martin',
+          prenom: 'Bob',
+          sexe: '',
+          lv2: '',
+          opt: '',
+          disso: '',
+          asso: '',
+          scores: { C: 0, T: 0, P: 0, A: 0 },
+          source: '',
+          dispo: '',
+          mobilite: 'LIBRE',
+        },
+      ],
+    },
+  ]);
+
+  assert.deepStrictEqual(eleves, expected);
+
+  const rules = service.getStructureRules();
+  const expectedRules = domain.sanitize({
+    '6E1': { capacity: 28, quotas: { ITA: 12 } },
+  });
+  assert.deepStrictEqual(rules, expectedRules);
+});
+
+test('ElevesBackend service bascule sur TEST pour un mode inconnu', () => {
+  const sandbox = loadBackendSandbox();
+  const ElevesBackend = sandbox.ElevesBackend;
+
+  const suffixes = [];
+  const dataAccess = {
+    getClassSheetsForSuffix: (suffix) => {
+      suffixes.push(suffix);
+      return [];
+    },
+    getStructureSheetValues: () => null,
+  };
+
+  const logger = { log: () => {}, warn: () => {}, error: () => {} };
+  const domain = ElevesBackend.createDomain({ config: ElevesBackend.config, logger });
+  const service = ElevesBackend.createService({
+    config: ElevesBackend.config,
+    domain,
+    dataAccess,
+    logger,
+  });
+
+  const result = service.getElevesDataForMode('INCONNU');
+  assert.ok(Array.isArray(result));
+  assert.strictEqual(result.length, 0);
+  assert.deepStrictEqual(suffixes, [ElevesBackend.config.sheetSuffixes.test]);
+});

--- a/tests/executerPhaseScoresSpecialisee.test.js
+++ b/tests/executerPhaseScoresSpecialisee.test.js
@@ -30,7 +30,7 @@ test('utilise le fallback V2 quand la stratégie spécialisée échoue', () => {
   sandbox.executerEquilibrageScoresPersonnalise = () => ({ success: false });
   sandbox.V2_Ameliore_OptimisationEngine = (sheet, dataContext, config) => {
     fallbackInvocations += 1;
-    assert.deepStrictEqual(config.COLONNES_SCORES_ACTIVES, scenarios);
+    assert.deepStrictEqual(Array.from(config.COLONNES_SCORES_ACTIVES), scenarios);
     return {
       success: true,
       nbSwapsAppliques: 4,

--- a/tests/getEleveById.test.js
+++ b/tests/getEleveById.test.js
@@ -35,3 +35,87 @@ test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () 
   assert.strictEqual(eleve.scores.P, 0);
   assert.strictEqual(eleve.scores.A, 0);
 });
+
+test('getEleveById_ accepte la colonne strictement nommée ID mais ignore ID_PARENT', () => {
+  const data = [
+    ['ID_PARENT', 'ID', 'Nom'],
+    ['P-001', 'XYZ999', 'Martin'],
+  ];
+
+  const fakeSheet = {
+    getName: () => '5E2TEST',
+    getDataRange: () => ({
+      getValues: () => data,
+    }),
+  };
+
+  const sandbox = loadBackendSandbox({
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({
+        getSheets: () => [fakeSheet],
+      }),
+    },
+  });
+
+  const eleve = sandbox.getEleveById_('XYZ999');
+
+  assert.ok(eleve, 'La colonne ID doit être reconnue.');
+  assert.strictEqual(eleve.id, 'XYZ999');
+  assert.strictEqual(eleve.nom, 'Martin');
+});
+
+test('getEleveById_ privilégie ID_ELEVE même en présence de colonnes ID_PARENT', () => {
+  const data = [
+    ['ID_PARENT', 'ID_ELEVE', 'Nom'],
+    ['P-001', 'ABC001', 'Alice'],
+    ['P-002', 'ABC002', 'Bob'],
+  ];
+
+  const fakeSheet = {
+    getName: () => '4E3TEST',
+    getDataRange: () => ({
+      getValues: () => data,
+    }),
+  };
+
+  const sandbox = loadBackendSandbox({
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({
+        getSheets: () => [fakeSheet],
+      }),
+    },
+  });
+
+  const eleve = sandbox.getEleveById_('ABC002');
+
+  assert.ok(eleve, 'L\'alias ID_ELEVE doit être prioritaire.');
+  assert.strictEqual(eleve.id, 'ABC002');
+  assert.strictEqual(eleve.nom, 'Bob');
+});
+
+test('getEleveById_ retourne null lorsqu\'aucune colonne aliasée ID n\'est disponible', () => {
+  const data = [
+    ['ID_PARENT', 'Nom'],
+    ['P-001', 'Alice'],
+    ['P-002', 'Bob'],
+  ];
+
+  const fakeSheet = {
+    getName: () => '4E3TEST',
+    getDataRange: () => ({
+      getValues: () => data,
+    }),
+  };
+
+  const sandbox = loadBackendSandbox({
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({
+        getSheets: () => [fakeSheet],
+      }),
+    },
+  });
+
+  const eleve = sandbox.getEleveById_('ABC002');
+
+  assert.strictEqual(eleve, null);
+});

--- a/tests/getEleveById.test.js
+++ b/tests/getEleveById.test.js
@@ -1,29 +1,6 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
-
-function loadBackendSandbox(overrides = {}) {
-  const sandbox = {
-    console: { log: () => {}, warn: () => {}, error: () => {} },
-    Logger: { log: () => {} },
-    SpreadsheetApp: {
-      getActiveSpreadsheet: () => ({ getSheets: () => [] })
-    },
-  };
-
-  sandbox.global = sandbox;
-  sandbox.globalThis = sandbox;
-  sandbox.self = sandbox;
-
-  const filePath = path.join(__dirname, '..', 'BackendV2.js');
-  const code = fs.readFileSync(filePath, 'utf8');
-  vm.runInNewContext(code, sandbox, { filename: 'BackendV2.js' });
-
-  Object.assign(sandbox, overrides);
-  return sandbox;
-}
+const { loadBackendSandbox } = require('./helpers/loadBackendSandbox');
 
 test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () => {
   const data = [
@@ -54,7 +31,7 @@ test('getEleveById_ accepte les alias ID_ELEVE pour la colonne identifiant', () 
   assert.strictEqual(eleve.prenom, 'Alice');
   assert.strictEqual(eleve.mobilite, 'LIBRE');
   assert.strictEqual(eleve.scores.C, 42);
-  assert.strictEqual(eleve.scores.T, undefined);
-  assert.strictEqual(eleve.scores.P, undefined);
-  assert.strictEqual(eleve.scores.A, undefined);
+  assert.strictEqual(eleve.scores.T, 0);
+  assert.strictEqual(eleve.scores.P, 0);
+  assert.strictEqual(eleve.scores.A, 0);
 });

--- a/tests/helpers/loadBackendSandbox.js
+++ b/tests/helpers/loadBackendSandbox.js
@@ -1,0 +1,26 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadBackendSandbox(overrides = {}) {
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: { log: () => {} },
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => ({ getSheets: () => [] })
+    },
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', '..', 'BackendV2.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'BackendV2.js' });
+
+  Object.assign(sandbox, overrides);
+  return sandbox;
+}
+
+module.exports = { loadBackendSandbox };

--- a/tests/helpers/loadNirvanaSandbox.js
+++ b/tests/helpers/loadNirvanaSandbox.js
@@ -1,0 +1,71 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createDefaultSpreadsheet() {
+  const alerts = [];
+  const toasts = [];
+  return {
+    _alerts: alerts,
+    _toasts: toasts,
+    toast(message, title, seconds) {
+      toasts.push({ message, title, seconds });
+    },
+    getUi() {
+      return {
+        ButtonSet: { OK: 'OK' },
+        _alerts: alerts,
+        alert(title, message, button) {
+          alerts.push({ title, message, button });
+        }
+      };
+    }
+  };
+}
+
+function loadNirvanaSandbox(overrides = {}) {
+  const spreadsheet = createDefaultSpreadsheet();
+
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {}
+    },
+    LockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {}
+      })
+    },
+    SpreadsheetApp: {
+      getActiveSpreadsheet: () => spreadsheet
+    },
+    Date,
+    JSON,
+    Math,
+    Number,
+    String,
+    Array,
+    Object,
+    RegExp,
+    Error,
+    isFinite
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  const filePath = path.join(__dirname, '..', '..', 'Nirvana_Combined_Orchestrator.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'Nirvana_Combined_Orchestrator.js' });
+
+  Object.assign(sandbox, overrides);
+  sandbox.__spreadsheet = spreadsheet;
+
+  return sandbox;
+}
+
+module.exports = { loadNirvanaSandbox };

--- a/tests/nirvanaDataBackend.test.js
+++ b/tests/nirvanaDataBackend.test.js
@@ -1,0 +1,132 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function loadNirvanaDataSandbox(overrides = {}) {
+  const sandbox = {
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    Logger: { log: () => {}, warn: () => {}, error: () => {} },
+    Date,
+    Math,
+    Number,
+    String,
+    Array,
+    Object,
+    JSON,
+    RegExp,
+    Error
+  };
+
+  sandbox.global = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+
+  Object.assign(sandbox, overrides);
+
+  const filePath = path.join(__dirname, '..', 'Nirvana_DataBackend.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  vm.runInNewContext(code, sandbox, { filename: 'Nirvana_DataBackend.js' });
+
+  return sandbox;
+}
+
+test('NirvanaDataBackend.prepareData construit un contexte complet', () => {
+  const computeDistribution = (students, criteria) => {
+    const distribution = {};
+    criteria.forEach(critere => {
+      distribution[critere] = { '1': 0, '2': 0, '3': 0, '4': 0 };
+    });
+
+    students.forEach(student => {
+      criteria.forEach(critere => {
+        const value = student?.[critere];
+        const key = value !== undefined && value !== null ? String(value) : null;
+        if (key && Object.prototype.hasOwnProperty.call(distribution[critere], key)) {
+          distribution[critere][key] += 1;
+        }
+      });
+    });
+
+    return distribution;
+  };
+
+  const sandbox = loadNirvanaDataSandbox();
+  const { NirvanaDataBackend } = sandbox;
+  const logs = [];
+
+  const domain = NirvanaDataBackend.createDomain({
+    computeDistribution,
+    buildDissocCountMap: () => ({}) ,
+    logger: { log: () => {}, warn: () => {}, error: () => {} }
+  });
+
+  const service = NirvanaDataBackend.createService({
+    domain,
+    getConfig: () => ({ TEST_SUFFIX: 'TEST' }),
+    determineActiveLevel: () => 'TROISIEME',
+    loadStructure: () => ({ success: true, structure: { classes: [] } }),
+    buildOptionPools: () => ({ ESP: ['3A_TEST'] }),
+    loadStudents: () => ({
+      success: true,
+      students: [
+        { ID_ELEVE: 'E1', CLASSE: '3A_TEST', SEXE: 'F', COM: 1, TRA: 2, PART: 3 },
+        { ID_ELEVE: 'E2', CLASSE: '3B_TEST', SEXE: 'M', COM: 2, TRA: 3, PART: 4 }
+      ],
+      colIndexes: { ID_ELEVE: 0 }
+    }),
+    sanitizeStudents: rows => ({ clean: rows }),
+    classifyStudents: (rows, criteria) => {
+      logs.push({ rows: rows.length, criteria });
+    },
+    criteria: ['COM', 'TRA', 'PART'],
+    logger: { log: () => {}, warn: () => {}, error: () => {} }
+  });
+
+  const context = service.prepareData();
+
+  assert.equal(context.totalEleves, 2);
+  assert.equal(context.nbClasses, 2);
+  assert.deepEqual(Object.keys(context.classesState).sort(), ['3A_TEST', '3B_TEST']);
+  assert.equal(context.classesState['3A_TEST'].length, 1);
+  assert.equal(context.classesState['3B_TEST'].length, 1);
+  assert.deepEqual(context.optionPools, { ESP: ['3A_TEST'] });
+  assert.deepEqual(context.colIndexes, { ID_ELEVE: 0 });
+  assert.equal(context.ciblesParClasse['3A_TEST'].COM['1'], 1);
+  assert.equal(context.ciblesParClasse['3B_TEST'].COM['2'], 1);
+  assert.equal(context.classeCaches['3A_TEST'].parite.total, 0);
+  assert.equal(logs.length, 1);
+});
+
+test('NirvanaDataBackend.prepareData signale les erreurs de classification sans échouer', () => {
+  const warnings = [];
+
+  const sandbox = loadNirvanaDataSandbox();
+  const { NirvanaDataBackend } = sandbox;
+
+  const domain = NirvanaDataBackend.createDomain({
+    computeDistribution: () => ({ COM: { '1': 0, '2': 0, '3': 0, '4': 0 } }),
+    buildDissocCountMap: () => ({})
+  });
+
+  const service = NirvanaDataBackend.createService({
+    domain,
+    getConfig: () => ({}),
+    determineActiveLevel: () => null,
+    loadStructure: () => ({ success: true, structure: {} }),
+    buildOptionPools: () => ({}),
+    loadStudents: () => ({ success: true, students: [{ CLASSE: '3A_TEST' }], colIndexes: {} }),
+    sanitizeStudents: rows => ({ clean: rows }),
+    classifyStudents: () => {
+      throw new Error('boom');
+    },
+    criteria: ['COM'],
+    logger: { log: () => {}, warn: message => warnings.push(message), error: () => {} }
+  });
+
+  const context = service.prepareData();
+  assert.equal(context.totalEleves, 1);
+  assert.equal(context.nbClasses, 1);
+  assert.ok(warnings.length >= 1);
+});

--- a/tests/nirvanaEngine.test.js
+++ b/tests/nirvanaEngine.test.js
@@ -1,0 +1,115 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { loadNirvanaSandbox } = require('./helpers/loadNirvanaSandbox');
+
+function createTimeProvider(instants) {
+  let index = 0;
+  return () => {
+    const value = instants[index];
+    if (index < instants.length - 1) {
+      index += 1;
+    }
+    return value instanceof Date ? value : new Date(value);
+  };
+}
+
+test('NirvanaEngine domain agrège les résultats et formate le message', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.NirvanaEngine.createDomain({ logger: sandbox.Logger });
+
+  const start = new Date('2025-01-01T10:00:00Z');
+  const end = new Date('2025-01-01T10:00:10Z');
+
+  const summary = domain.runCombined({
+    config: { demo: true },
+    dataContext: { classesState: {} },
+    runV2Phase: () => ({ swapsV2: [1, 2, 3], cyclesGeneraux: 2, cyclesParite: 1 }),
+    runParityPhase: () => ({ nbApplied: 4 }),
+    computeState: () => ({ scoreGlobal: 87.1234 }),
+    now: createTimeProvider([end]),
+    startedAt: start
+  });
+
+  assert.equal(summary.success, true);
+  assert.equal(summary.swapsV2, 3);
+  assert.equal(summary.cyclesGeneraux, 2);
+  assert.equal(summary.cyclesParite, 1);
+  assert.equal(summary.operationsParity, 4);
+  assert.equal(summary.totalOperations, 7);
+  assert.equal(summary.tempsMs, 10000);
+  assert.equal(summary.scoreFinal, 87.1234);
+  assert.equal(summary.startedAt.toISOString(), start.toISOString());
+  assert.equal(summary.endedAt.toISOString(), end.toISOString());
+
+  const message = domain.formatSuccess(summary);
+  assert.match(message, /Swaps principaux: 3/);
+  assert.match(message, /Corrections parité: 4/);
+  assert.match(message, /Score final: 87\.12\/100/);
+  assert.match(message, /Durée totale: 10\.0 secondes/);
+});
+
+test('NirvanaEngine service orchestre les verrous et interactions UI', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.NirvanaEngine.createDomain({ logger: sandbox.Logger });
+
+  let released = false;
+  const toasts = [];
+  const alerts = [];
+
+  const spreadsheet = {
+    toast(message, title, seconds) {
+      toasts.push({ message, title, seconds });
+    },
+    getUi() {
+      return {
+        ButtonSet: { OK: 'OK' },
+        alert(title, message, button) {
+          alerts.push({ title, message, button });
+        }
+      };
+    }
+  };
+
+  const service = sandbox.NirvanaEngine.createService({
+    domain,
+    getConfig: () => ({ demo: true }),
+    prepareData: () => ({ classesState: {} }),
+    runV2Phase: () => ({ swapsV2: ['a'], cyclesGeneraux: 1, cyclesParite: 2 }),
+    runParityPhase: () => ({ nbApplied: 3 }),
+    computeState: () => ({ scoreGlobal: 91 }),
+    spreadsheetApp: { getActiveSpreadsheet: () => spreadsheet },
+    lockService: {
+      getScriptLock: () => ({
+        tryLock: () => true,
+        releaseLock: () => {
+          released = true;
+        }
+      })
+    },
+    logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {}
+    },
+    now: createTimeProvider([
+      new Date('2025-01-01T08:00:00Z'),
+      new Date('2025-01-01T08:00:05Z'),
+      new Date('2025-01-01T08:00:07Z')
+    ])
+  });
+
+  const result = service.runCombination();
+
+  assert.equal(result.success, true);
+  assert.equal(result.swapsV2, 1);
+  assert.equal(result.operationsParity, 3);
+  assert.equal(result.totalOperations, 4);
+  assert.equal(result.scoreFinal, 91);
+  assert.equal(result.tempsMs, 5000);
+  assert.equal(released, true);
+  assert.equal(toasts.length, 4);
+  assert.equal(alerts.length, 1);
+  assert.match(alerts[0].message, /Swaps principaux: 1/);
+  assert.match(toasts[toasts.length - 1].message, /4 opérations appliquées/);
+});

--- a/tests/scoresPhaseEngine.test.js
+++ b/tests/scoresPhaseEngine.test.js
@@ -1,0 +1,116 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { loadNirvanaSandbox } = require('./helpers/loadNirvanaSandbox');
+
+test('ScoresEquilibrageEngine domain returns specialised success', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.ScoresEquilibrageEngine.createDomain({ logger: sandbox.Logger });
+
+  const result = domain.run({
+    scenarios: ['COM'],
+    runCustom: () => ({
+      success: true,
+      nbOperations: 3,
+      details: { strategieUtilisee: 'Spécialisée COM' }
+    })
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.nbOperations, 3);
+  assert.strictEqual(result.details.strategieUtilisee, 'Spécialisée COM');
+  assert.ok(Array.isArray(result.details.history));
+  assert.strictEqual(result.details.history.length, 1);
+  const [entry] = result.details.history;
+  assert.strictEqual(entry.type, 'specialisee');
+  assert.strictEqual(entry.success, true);
+  assert.deepStrictEqual({ ...entry.details }, { strategieUtilisee: 'Spécialisée COM' });
+});
+
+test('ScoresEquilibrageEngine domain falls back when specialised fails', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.ScoresEquilibrageEngine.createDomain({ logger: sandbox.Logger });
+  let fallbackCalled = 0;
+
+  const result = domain.run({
+    scenarios: ['COM'],
+    runCustom: () => ({
+      success: false,
+      nbOperations: 0,
+      details: { strategieUtilisee: 'Spécialisée COM' }
+    }),
+    runFallback: () => {
+      fallbackCalled += 1;
+      return {
+        success: true,
+        nbOperations: 5,
+        details: { strategieUtilisee: 'V2 Adaptée Scores' }
+      };
+    }
+  });
+
+  assert.strictEqual(fallbackCalled, 1);
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.nbOperations, 5);
+  assert.strictEqual(result.details.strategieUtilisee, 'V2 Adaptée Scores');
+  assert.strictEqual(result.details.history.length, 2);
+  const [, fallbackEntry] = result.details.history;
+  assert.strictEqual(fallbackEntry.type, 'fallback');
+  assert.strictEqual(fallbackEntry.success, true);
+});
+
+test('ScoresEquilibrageEngine domain fails gracefully without scenarios', () => {
+  const sandbox = loadNirvanaSandbox();
+  const domain = sandbox.ScoresEquilibrageEngine.createDomain({ logger: sandbox.Logger });
+
+  const result = domain.run({ scenarios: [] });
+
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.nbOperations, 0);
+  assert.strictEqual(result.details.strategieUtilisee, 'Aucune');
+  assert.ok(Array.isArray(result.details.history));
+  assert.strictEqual(result.details.history.length, 0);
+});
+
+test('ScoresEquilibrageEngine service prepares config and triggers fallback', () => {
+  const sandbox = loadNirvanaSandbox();
+  const captured = [];
+
+  const service = sandbox.ScoresEquilibrageEngine.createService({
+    runCustomPhase: ({ config }) => {
+      captured.push({ stage: 'specialisee', config: { ...config } });
+      return {
+        success: false,
+        nbOperations: 0,
+        details: { strategieUtilisee: 'Spécialisée COM+TRA' }
+      };
+    },
+    runFallbackPhase: ({ config }) => {
+      captured.push({ stage: 'fallback', config: { ...config } });
+      return {
+        success: true,
+        nbOperations: 7,
+        details: { strategieUtilisee: 'V2 Adaptée Scores', cyclesGeneraux: 2 }
+      };
+    }
+  });
+
+  const baseConfig = { MODE_AGRESSIF: false, seuil: 1 };
+  const result = service.runPhase({
+    dataContext: { classesState: {} },
+    config: baseConfig,
+    scenarios: ['COM', 'TRA']
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.nbOperations, 7);
+  assert.strictEqual(result.details.cyclesGeneraux, 2);
+  assert.deepStrictEqual(Array.from(result.details.scenarios), ['COM', 'TRA']);
+  assert.strictEqual(captured.length, 2);
+  assert.deepStrictEqual(Array.from(captured[0].config.COLONNES_SCORES_ACTIVES), ['COM', 'TRA']);
+  assert.strictEqual(captured[0].config.MODE_AGRESSIF, true);
+  assert.strictEqual(captured[0].config.MAX_ITERATIONS_SCORES, 50);
+  assert.strictEqual(captured[1].config.MODE_AGRESSIF, true);
+  assert.strictEqual(captured[1].config.MAX_ITERATIONS_SCORES, 50);
+  assert.deepStrictEqual(Array.from(captured[1].config.COLONNES_SCORES_ACTIVES), ['COM', 'TRA']);
+});


### PR DESCRIPTION
## Summary
- add the NirvanaDataBackend domain/service to centralize class aggregation and target calculations for Nirvana engines
- rewrite V2_Ameliore_PreparerDonnees* wrappers (and the SEXE patch) to delegate to the shared service and expose the helper globally
- extend the documentation and test suite with dedicated coverage for the new data backend module

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68cb949010a48327993c52290d624535